### PR TITLE
ci: add multiple node versions for test pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,15 @@ jobs:
   build:
     name: Testing
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
-      - name: Testing with Node 20
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - name: Run Linting
         run: npm run lint


### PR DESCRIPTION
Fix #696 

Objective of PR:

- Execute test pipeline in multiple Node versions (18, 20 & 22)