### PR TITLE
A pre-commit hook for linting.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/parser": "8.14.0",
         "eslint": "9.14.0",
         "globals": "15.12.0",
+        "husky": "^9.1.6",
         "jest": "29.7.0",
         "typescript": "5.6.3",
         "typescript-eslint": "8.13.0"
@@ -2868,6 +2869,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepare": "tsc",
+    "prepare": "husky",
     "pretest": "tsc",
     "test": "jest dist/index.spec.js",
-    "lint": "eslint index.ts"
+    "lint": "eslint index.ts",
+    "prepare:husky": "husky install"
   },
   "license": "MIT",
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@typescript-eslint/parser": "8.14.0",
     "eslint": "9.14.0",
     "globals": "15.12.0",
+    "husky": "^9.1.6",
     "jest": "29.7.0",
     "typescript": "5.6.3",
     "typescript-eslint": "8.13.0"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepare": "husky",
+    "prepare": "tsc",
     "pretest": "tsc",
     "test": "jest dist/index.spec.js",
     "lint": "eslint index.ts",
     "prepare:husky": "husky install"
+
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This PR addresses the issue #728, and the objective is to add a pre commit hook for linting.

The linting is done using a tool called husky. and the configs for the pre commit hook can be found in the `.husky/pre-commit` file. 

Please let me if any others changes are required. Thank you.